### PR TITLE
Plugin crashes when the file doesn't exist yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,16 +21,21 @@ function getAllFiles(root) {
 
 function replace(file, rules) {
 	const src = path.resolve(file);
-	let template = fs.readFileSync(src, 'utf8');
+	
+	try {
+		let template = fs.readFileSync(src, 'utf8');
 
-	template = rules.reduce(
-		(template, rule) => template.replace(
-			rule.search, (typeof rule.replace === 'string' ? rule.replace : rule.replace.bind(global))
-		),
-		template
-	);
+		template = rules.reduce(
+			(template, rule) => template.replace(
+				rule.search, (typeof rule.replace === 'string' ? rule.replace : rule.replace.bind(global))
+			),
+			template
+		);
 
-	fs.writeFileSync(src, template);
+		fs.writeFileSync(src, template);
+	} catch (err) {
+		return
+	}
 }
 
 function ReplaceInFilePlugin(options = []) {


### PR DESCRIPTION
This plugin work very well for me, but it always searched for a file that is on my git ignore, so when I clone my repo in other computer this plugin crashed my web server because the file is not yet created.

I added a little try catch to solve it.