### PR TITLE
Add instructions for multiple replacements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ You can pass an array of configuration options to `ReplaceInFileWebpackPlugin`. 
 - `files`: Optional. Files in `dir` to find for replacement.
 - `test`: Optional. Regex expression or Regex expressions array to match files in `dir`.
 - `rules`: Required. Replace content rules array. Each rule has `search` and `replace` properties.
-- `search`: Required. String or Regex expression used for searching content in files.
-- `replace`: Required. String or funcion used for replacing the searching content.
+- `search`: Required. String or Regex expression used for searching content in files. If multiple instances need to be replaced, use a Regex expression
+- `replace`: Required. String or function used for replacing the searching content.
 
 # License
 


### PR DESCRIPTION
Without knowing how the plugin works under the hood, i.e. that it uses JavaScript's `.replace()` function, users aren't going to know that only the first instance of their search term will be replaced.
This PR adds a simple bit of helper text that indicates to users how best to set up their `search` property if they need to replace multiple instances