### PR TITLE
Allow to pass used hook to plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,21 +35,19 @@ function replace(file, rules) {
 
 function ReplaceInFilePlugin(options = []) {
 	this.options = options;
-};
+}
 
 ReplaceInFilePlugin.prototype.apply = function (compiler) {
 	const root = compiler.options.context;
-	const done = (statsData) => {
-		if (statsData.hasErrors()) {
-			return
-		}
-		this.options.forEach(option => {
-			const dir = option.dir || root;
-			const files = option.files;
 
-			if(option.files){
+	this.options.forEach(option => {
+
+		const done = () => {
+			const dir = option.dir || root;
+
+			if (option.files) {
 				const files = option.files;
-				if(Array.isArray(files) && files.length) {
+				if (Array.isArray(files) && files.length) {
 					files.forEach(file => {
 						replace(path.resolve(dir, file), option.rules);
 					})
@@ -76,17 +74,20 @@ ReplaceInFilePlugin.prototype.apply = function (compiler) {
 					replace(file, option.rules);
 				})
 			}
-		})
-	}
 
-	if (compiler.hooks) {
-		const plugin = {
-			name: "ReplaceInFilePlugin"
-		};
-		compiler.hooks.done.tap(plugin, done);
-	} else {
-		compiler.plugin('done', done);
-	}
+		}
+
+		const {hook = 'done'} = option;
+
+		if (compiler.hooks) {
+			compiler.hooks[hook].tap({
+				name: "ReplaceInFilePlugin"
+			}, done);
+		} else {
+			compiler.plugin(hook, done);
+		}
+
+	})
 };
 
 module.exports = ReplaceInFilePlugin;


### PR DESCRIPTION
Hi

I run into a problem to use this plugin in conjunction with the filemanager-webpack-plugin plugin.

The problem occurred because the filemanager plugin was executed on the 'afterEmit' hook whilst replace-in-file executes on the 'done' hook.

Therefore the files were copied before the content was replaced.

To fix this I introduced a new `hook` property as a configuration option.
It allows to specify which compiler hook the plugin should use and defaults to 'done'.

I had to restructure the code a bit and move the callback inside the `forEach` loop to allow a different 'hook' value per option.


Regards
Peter

**Sidenote**
I removed this condition because I didn't need it for my purpose but if you think this changes makes sense to be merged, I am happy to add it back.

```
if (statsData.hasErrors()) {
    return
}
```
